### PR TITLE
using no-cros mode

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -114,7 +114,8 @@ export class Auth {
             headers: {
                 'Content-type': 'application/json',
                 'Authorization': token
-            }
+            },
+            mode: 'no-cors'
         };
 
         return fetch(call_url, request)


### PR DESCRIPTION
@briehl Getting an error 

`Access to fetch at 'https://ci.kbase.us/services/auth/api/V2/token' from origin 'http://localhost:8888' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.`

Is this how I should fix it? 